### PR TITLE
Customize position and target

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,12 @@ Configuration
 It is possible to configure the output to achieve something more to your own
 liking.
 
+``indent-info-insert-target``
+	Target list for insertion of ``indent-info-mode``.
+
+``indent-info-insert-position``
+	Position for insertion of ``indent-info-mode``.
+
 ``indent-info-prefix``
 	Text to display before the indentation info in the mode line.
 

--- a/indent-info.el
+++ b/indent-info.el
@@ -35,6 +35,18 @@
   "Display indentation information in mode line."
   :group 'modeline)
 
+(defcustom indent-info-insert-target 'mode-line-position
+  "Target list for insertion of `indent-info-mode'."
+  :type 'symbol
+  :group 'indent-info)
+
+(defcustom indent-info-insert-position 'before
+  "Position for insertion of `indent-info-mode'.
+Choices are `before', `after'."
+  :type '(choice (const :tag "Before insert target" before)
+                 (const :tag "After insert target" after))
+  :group 'indent-info)
+
 (defcustom indent-info-prefix " "
   "Text to display before the indentation info in the mode line."
   :type 'string
@@ -162,9 +174,11 @@ When enabled, information about the currently configured `indent-tabs-mode' and
 `tab-width' is displayed in the mode line."
   :lighter nil :global nil
   (if indent-info-mode
-      (add-to-list 'mode-line-position
-                   '(indent-info-mode (:eval (indent-info-mode-line))))
-    (setq mode-line-position (assq-delete-all 'indent-info-mode mode-line-position))))
+      (add-to-list indent-info-insert-target
+                   '(indent-info-mode (:eval (indent-info-mode-line)))
+                   (eq indent-info-insert-position 'after))
+    (set indent-info-insert-target
+         (assq-delete-all 'indent-info-mode (symbol-value indent-info-insert-target)))))
 
 ;;;###autoload
 (define-global-minor-mode global-indent-info-mode
@@ -173,10 +187,5 @@ When enabled, information about the currently configured `indent-tabs-mode' and
   :group 'indent-info)
 
 (provide 'indent-info)
-
-;; Local Variables:
-;; coding: utf-8
-;; checkdoc-minor-mode: t
-;; End:
 
 ;;; indent-info.el ends here


### PR DESCRIPTION
This introduces two new options:

- `indent-info-insert-target` represents the target list (defaults to: `mode-line-position`)
- `indent-info-insert-position` represents the position, if it should be added
  before/after the list (defaults to before).

Fixes #5 